### PR TITLE
extendsを外して、persister, executer, reporterを定義

### DIFF
--- a/src/test/scala/com/jellyfish85/P09Bench.scala
+++ b/src/test/scala/com/jellyfish85/P09Bench.scala
@@ -2,7 +2,19 @@ package com.jellyfish85
 
 import org.scalameter.api._
 
-class P09Bench extends PerformanceTest.Microbenchmark {
+class P09Bench extends PerformanceTest {
+   lazy val executor  = LocalExecutor(new Executor.Warmer.Default, Aggregator.min, new Measurer.Default)
+   lazy val persistor = Persistor.None
+   lazy val reporter  = Reporter.Composite(
+         new RegressionReporter(
+                     RegressionReporter.Tester.OverlapIntervals(),
+                     RegressionReporter.Historian.ExponentialBackoff()
+                 ),
+                 HtmlReporter(true)
+               )
+   //lazy val reporter = new LoggingReporter
+   //lazy val reporter = ChartReporter(ChartFactory.XYLine())
+   
    val p09 = new P09()
 
    val sizes = Gen.range("size")(0, 100000, 10000)


### PR DESCRIPTION
reporterでhtml出力をしたかったので、オプションを変更してフィールドに実装
